### PR TITLE
Create new payment lazily to avoid creating to many transactions.

### DIFF
--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -74,8 +74,6 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface, Generic
         $token = $request->getToken();
         $payUdata = $this->prepareOrder($token, $order);
 
-        $result = $this->openPayUBridge->create($payUdata);
-
         if (null !== $model['orderId']) {
             /** @var mixed $response */
             $response = $this->openPayUBridge->retrieve((string) $model['orderId'])->getResponse();
@@ -88,6 +86,8 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface, Generic
                 return;
             }
         }
+
+        $result = $this->openPayUBridge->create($payUdata);
 
         if (null !== $result) {
             /** @var mixed $response */


### PR DESCRIPTION
The current implementation tries to create new transactions too fast. This is a problem, especially after coming back from PayU. In this case, we don't need to create a new payment. We should retrieve information and only create payment if necessary. 

In our business case, we send payment id as `extOrderId`. When we come back from Payu in the current implementation we got the exception `ERROR_ORDER_NOT_UNIQUE`.

I think this might be related to #19 