### PR TITLE
Set error http response code when occurs error in notify action.

### DIFF
--- a/src/Action/NotifyAction.php
+++ b/src/Action/NotifyAction.php
@@ -93,7 +93,7 @@ final class NotifyAction implements ActionInterface, ApiAwareInterface
                     }
                 }
             } catch (OpenPayU_Exception $e) {
-                throw new HttpResponse($e->getMessage());
+                throw new HttpResponse($e->getMessage(), 500);
             }
         }
     }


### PR DESCRIPTION
Without this change PayU never resends notifications.