### PR TITLE
Make transaction description configurable.

### DIFF
--- a/src/Provider/PaymentDescriptionProvider.php
+++ b/src/Provider/PaymentDescriptionProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file was created by developers working at BitBag
+ * Do you need more information about us and what we do? Visit our https://bitbag.io website!
+ * We are hiring developers from all over the world. Join us and start your new, exciting adventure and become part of us: https://bitbag.io/career
+*/
+
+declare(strict_types=1);
+
+namespace BitBag\SyliusPayUPlugin\Provider;
+
+use Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProviderInterface;
+use Sylius\Component\Core\Model\PaymentInterface;
+
+final class PaymentDescriptionProvider implements PaymentDescriptionProviderInterface
+{
+    public function getPaymentDescription(PaymentInterface $payment): string
+    {
+        $order = $payment->getOrder();
+
+        return $order->getNumber();
+    }
+}

--- a/src/Resources/config/services/action.xml
+++ b/src/Resources/config/services/action.xml
@@ -6,6 +6,7 @@
 
         <service id="bitbag.payu_plugin.action.capture" class="BitBag\SyliusPayUPlugin\Action\CaptureAction">
             <argument type="service" id="bitbag.payu_plugin.bridge.open_payu"/>
+            <argument type="service" id="bitbag.payu_plugin.provider.payment_description_provider"/>
             <tag name="payum.action" factory="payu" alias="payum.action.capture"/>
         </service>
 

--- a/src/Resources/config/services/provider.xml
+++ b/src/Resources/config/services/provider.xml
@@ -1,0 +1,10 @@
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+
+        <defaults public="true" autoconfigure="false" autowire="false"/>
+
+        <service id="bitbag.payu_plugin.provider.payment_description_provider" class="BitBag\SyliusPayUPlugin\Provider\PaymentDescriptionProvider">
+        </service>
+    </services>
+</container>

--- a/tests/spec/Action/CaptureActionSpec.php
+++ b/tests/spec/Action/CaptureActionSpec.php
@@ -21,15 +21,18 @@ use Payum\Core\GatewayInterface;
 use Payum\Core\Request\Capture;
 use Payum\Core\Security\TokenInterface;
 use PhpSpec\ObjectBehavior;
+use Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProviderInterface;
 use Sylius\Component\Core\Model\CustomerInterface;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Model\OrderItemInterface;
 
 final class CaptureActionSpec extends ObjectBehavior
 {
-    function let(OpenPayUBridgeInterface $openPayUBridge): void
-    {
-        $this->beConstructedWith($openPayUBridge);
+    function let(
+        OpenPayUBridgeInterface $openPayUBridge,
+        PaymentDescriptionProviderInterface $paymentDescriptionProvider
+    ): void {
+        $this->beConstructedWith($openPayUBridge, $paymentDescriptionProvider);
     }
 
     function it_is_initializable(): void


### PR DESCRIPTION
In this PR I propose to make transaction description configurable. I think that it will be good to use Sylius interface: `\Sylius\Bundle\PayumBundle\Provider\PaymentDescriptionProviderInterface`. 

To avoid BC I've created a class that implements this interface and make the description the same as the previous. But this approach allows changing the description without decorating the whole Action. 